### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -203,12 +203,20 @@ func logResponse(logger *zap.Logger, c *gin.Context, rw *responseWriter, duratio
 // logDetailedRequest logs comprehensive request information
 func logDetailedRequest(logger *zap.Logger, c *gin.Context, requestBody []byte) {
 	headers := make(map[string]string)
+	// Only log safe headers; mask all others
+	safeHeaders := map[string]bool{
+		"User-Agent":  true,
+		"Referer":     true,
+		"Accept":      true,
+		"Accept-Language": true,
+		"Accept-Encoding": true,
+		"Content-Type": true,
+	}
 	for name, values := range c.Request.Header {
-		// Mask sensitive headers
-		if isSensitiveHeader(name) {
-			headers[name] = "[MASKED]"
-		} else {
+		if safeHeaders[name] {
 			headers[name] = strings.Join(values, ", ")
+		} else {
+			headers[name] = "[MASKED]"
 		}
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/FosterG4/Gmail-Cleaner-Pro/security/code-scanning/2](https://github.com/FosterG4/Gmail-Cleaner-Pro/security/code-scanning/2)

To fix the problem, we should ensure that only non-sensitive headers are logged, or that sensitive headers are reliably masked. The best approach is to use an allowlist of headers that are known to be safe to log (e.g., `User-Agent`, `Referer`, etc.), and mask or omit all others. This reduces the risk of leaking sensitive information due to incomplete masking logic. The changes should be made in the `logDetailedRequest` function in `internal/middleware/logging.go`, specifically in the loop that builds the `headers` map. We will introduce an allowlist of safe headers, and for any header not in the allowlist, we will mask its value. No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
